### PR TITLE
Fix JSON.parsing when streaming changes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -116,15 +116,31 @@ proto._callback = function (callback, options) {
 
 proto._stream = function (stream, callback, options) {
     if (options.changes) {
+        var buf = '', last_err = null, last_timer = null,
+            err_timeout = options.error_timeout || 500;
         stream.on("data", function (chunk) {
             if (typeof chunk !== "string") {
                 return;
             }
-            chunk = chunk.trim();
-            if (chunk.length === 0) {
+            buf += chunk.trim();
+            if (buf.length === 0) {
                 return;
             }
-            chunk = JSON.parse(chunk);
+            try {
+                chunk = JSON.parse(buf);
+                buf = '';
+                if (last_timer !== null) {
+                    clearTimeout(last_timer);
+                    last_timer = null;
+                }
+            } catch (err) {
+                last_err = err;
+                if (last_timer === null) {
+                    last_timer = setTimeout(function () {
+                        throw last_err;
+                    }, err_timeout);
+                }
+            }
             if (chunk.seq) {
                 stream.emit("change", chunk);
             }

--- a/lib/client.js
+++ b/lib/client.js
@@ -117,17 +117,19 @@ proto._callback = function (callback, options) {
 proto._stream = function (stream, callback, options) {
     if (options.changes) {
         stream.on("data", function (chunk) {
-            if (typeof chunk === "string") {
-                chunk = chunk.trim();
+            if (typeof chunk !== "string") {
+                return;
             }
-            if (chunk) {
-                chunk = JSON.parse(chunk);
-                if (chunk.seq) {
-                    stream.emit("change", chunk);
-                }
-                if (chunk.last_seq) {
-                    stream.emit("last", chunk.last_seq);
-                }
+            chunk = chunk.trim();
+            if (chunk.length === 0) {
+                return;
+            }
+            chunk = JSON.parse(chunk);
+            if (chunk.seq) {
+                stream.emit("change", chunk);
+            }
+            if (chunk.last_seq) {
+                stream.emit("last", chunk.last_seq);
             }
         });
     }


### PR DESCRIPTION
When streaming a lot of changes, a chunk might only be a partial JSON string, which results in the current code throwing a syntax error.
### Refactor proto._stream()

commit 4fe50608488b9d2c0419ffd099a9aa73b867056f

```
The goal of this patch is to remove noise from the next patch.

Reasoning:
- JSON.parse takes a string as input, therefore clearly reject
  non-strings.
- Since we now know that chunk is a string, directly check the length.

lib/client.js |   22 ++++++++++++----------
1 file changed, 12 insertions(+), 10 deletions(-)
```
### Handle JSON errors in proto._stream()

commit c901c234aa4f515ec5f0226c3542aeffc81fabeb

```
In order To handle partial JSON chunks, use a buffer, and only emit a
parse error if the buffer remains unparsable for the whole period
defined by the new error_timeout option (default: 500ms).

lib/client.js |   22 +++++++++++++++++++---
1 file changed, 19 insertions(+), 3 deletions(-)
```
