### PR TITLE
URI encode document key when generating URL

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -26,7 +26,7 @@ Object.defineProperty(proto, "id", {
     },
     set: function (v) {
         var path = this._url.pathname.split("/");
-        path.splice(2, v.split("/").length, v);
+        path.splice(2, v.split("/").length, encodeURIComponent(v));
         this.body._id = v;
         this._url.path = this._url.pathname = path.join("/");
     }


### PR DESCRIPTION
Trivial bugfix, might be needed other places too, but I assume that documents are most likely to have exotic keys.

Signed-off-by: Asbjørn Sloth Tønnesen ast@veridu.com
