### PR TITLE
Add the ability to modify request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ It uses callbacks that follow node.js conventions and aims to be as expressive a
 	// if you chose a non-existant db, you'd get { error: "not_found", reason: "no_db_file" } in place of `err`
     });
 
+    // It utilizes mikeal's [request module](https://github.com/mikeal/request) and exposes its methods via setRequestOptions method call on any couchdb entity
+    //i.e. 
+    db.setRequestOptions({ 
+	timeout: 2000,
+        // oauth signing, aws auth can be put here... 
+    }).info(function(err, response){
+          console.log(response);
+       });
+
 Refer to [my website](http://www.dbarnes.info/node-couchdb-api/) for documentation and resources.
 
 ## Changelog

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,25 @@ var request = require("request").defaults({ encoding: "utf8" }),
     proto   = {};
 
 /**
+ * Request options overrides
+ * @param Object
+ */
+proto._requestOpts = {};
+
+/**
+ * Method that allows to override
+ * request defaults such as headers, timeout etc
+ * @see https://github.com/mikeal/request
+ * @param {Object} [options]
+ *
+ * @return {Object} chainable
+ */
+proto.setRequestOptions = function(options) {
+    _.extend(this._requestOpts, options);
+    return this;
+}
+
+/**
  * Prepares the URL options before a request
  *
  * @param {String|Object} input
@@ -198,10 +217,11 @@ proto._get = function (url, options, callback) {
         callback = options;
         options = null;
     }
-
+    
     options = options || {};
     this._set_url(url, options);
-
+    _.extend(options, this._requestOpts);    
+    
     if (options.stream) {
         if (!options.changes) {
             options.encoding = null;
@@ -242,6 +262,8 @@ proto._put = function (url, body, options, callback) {
 
     options = options || {};
     this._set_url(url, options);
+    _.extend(options, this._requestOpts);
+    
     if (options.stream) {
         body.pipe(request.put(options, this._callback(callback, options)));
     } else {
@@ -282,7 +304,8 @@ proto._post = function (url, body, options, callback) {
     options = options || {};
     this._set_url(url, options);
     this._set_body(body, options);
-
+    _.extend(options, this._requestOpts);
+    
     request.post(options, this._callback(callback, options));
     return this;
 };
@@ -309,7 +332,8 @@ proto._del = function (url, options, callback) {
 
     options = options || {};
     this._set_url(url, options);
-
+    _.extend(options, this._requestOpts);
+    
     request.del(options, this._callback(callback, options));
     return this;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -220,7 +220,7 @@ proto._get = function (url, options, callback) {
     
     options = options || {};
     this._set_url(url, options);
-    _.extend(options, this._requestOpts);    
+    _.extend(options, this._requestOpts);
     
     if (options.stream) {
         if (!options.changes) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -217,11 +217,11 @@ proto._get = function (url, options, callback) {
         callback = options;
         options = null;
     }
-    
+
     options = options || {};
     this._set_url(url, options);
     _.extend(options, this._requestOpts);
-    
+
     if (options.stream) {
         if (!options.changes) {
             options.encoding = null;
@@ -263,7 +263,7 @@ proto._put = function (url, body, options, callback) {
     options = options || {};
     this._set_url(url, options);
     _.extend(options, this._requestOpts);
-    
+
     if (options.stream) {
         body.pipe(request.put(options, this._callback(callback, options)));
     } else {
@@ -305,7 +305,7 @@ proto._post = function (url, body, options, callback) {
     this._set_url(url, options);
     this._set_body(body, options);
     _.extend(options, this._requestOpts);
-    
+
     request.post(options, this._callback(callback, options));
     return this;
 };
@@ -333,7 +333,7 @@ proto._del = function (url, options, callback) {
     options = options || {};
     this._set_url(url, options);
     _.extend(options, this._requestOpts);
-    
+
     request.del(options, this._callback(callback, options));
     return this;
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -221,7 +221,8 @@ proto._get = function (url, options, callback) {
     options = options || {};
     this._set_url(url, options);
     _.extend(options, this._requestOpts);
-
+    this._requestOpts = {};
+    
     if (options.stream) {
         if (!options.changes) {
             options.encoding = null;
@@ -263,6 +264,7 @@ proto._put = function (url, body, options, callback) {
     options = options || {};
     this._set_url(url, options);
     _.extend(options, this._requestOpts);
+    this._requestOpts = {};
 
     if (options.stream) {
         body.pipe(request.put(options, this._callback(callback, options)));
@@ -305,6 +307,7 @@ proto._post = function (url, body, options, callback) {
     this._set_url(url, options);
     this._set_body(body, options);
     _.extend(options, this._requestOpts);
+    this._requestOpts = {};
 
     request.post(options, this._callback(callback, options));
     return this;
@@ -333,6 +336,7 @@ proto._del = function (url, options, callback) {
     options = options || {};
     this._set_url(url, options);
     _.extend(options, this._requestOpts);
+    this._requestOpts = {};
 
     request.del(options, this._callback(callback, options));
     return this;

--- a/test/request.js
+++ b/test/request.js
@@ -1,0 +1,42 @@
+var _ = require("underscore"),
+    test = require("assert"),
+    config = require("./config"),
+    couchdb = require("../"),
+    server = couchdb.srv(config.url);
+
+module.exports = {
+    before: function (done) {
+        if (!config.party) {
+            server.auth = [ config.user, config.pass ];
+        }
+        done();
+    },
+    after: function (done) {
+        done();
+    },
+
+    "Request": {
+        "Test chaining": function (done) {
+            test.strictEqual(server, server.setRequestOptions( { form: {} } ));
+            done();
+        },
+        
+        "Timeout occure": function(done) {
+            server.setRequestOptions({timeout:1}).info(function(err, body){
+                test.notEqual(err, null);
+                test.ok( err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT' );
+                test.equal(server._requestOpts, {});
+                done();
+            });
+        },
+        "Options are reset on the server object": function(done) {
+            server.info(function(err, body){
+                test.ifError(err);
+                if (!err) {
+                    test.equal(body.couchdb, "Welcome");
+                }
+                done();
+            })
+        }
+    }
+};


### PR DESCRIPTION
Adds a chaining method to a parent prototype, basically allows to modify request options if needed.

_Usage example:_

``` javascript
var db = require('couchdb-api').srv('http://hostname:port').db(myDatabase);

db.ddoc(myKey).view(myView).setRequestOptions({
       timeout: 3 * 1000
}).query({
        limit: 1
}, function(err, data) {
        // do something
});
```
